### PR TITLE
Abstract template storage into swappable backends and use the database by default

### DIFF
--- a/cohesion.module
+++ b/cohesion.module
@@ -8,6 +8,7 @@ use Drupal\cohesion_elements\Plugin\Field\FieldType\CohesionEntityReferenceRevis
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\tmgmt\JobItemInterface;
 use Drupal\tmgmt\JobInterface;
+use Drupal\cohesion\PublicFileStorage;
 use Drupal\cohesion_elements\Entity\CohesionLayout;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StreamWrapper\PublicStream;
@@ -413,48 +414,32 @@ function cohesion_css_alter(&$css, $assets) {
  * Allow loading of theme templates from the Site Studio template store.
  */
 function cohesion_theme_registry_alter(&$theme_registry) {
-  $template_location = COHESION_TEMPLATE_PATH;
-  $template_extension = '.html.twig';
-
-  /** @var \Drupal\Core\File\FileSystemInterface $file_system */
-  $file_system = \Drupal::service('file_system');
-
-  // Get real path to templates and extract relative path for theme hooks.
-  // Note: The theme registry expects template paths relative to DRUPAL_ROOT.
-  if ($wrapper = \Drupal::service('stream_wrapper_manager')
-    ->getViaUri($template_location)) {
-    $template_path = $wrapper->basePath() . '/cohesion/templates';
-  }
-  else {
-    // Do nothing if template path is not valid.
-    \Drupal::logger('cohesion')
-      ->error(t('Unable to get stream wrapper for Site Studio templates path: @uri', ['@uri' => $template_location]));
+  $template_path = PublicFileStorage::getTemplatePath();
+  if (empty($template_path)) {
     return FALSE;
   }
 
-  if(is_dir($template_path)){
-    // Scan for template files and override their location in the theme registry.
-    $template_files = $file_system->scanDirectory($template_path, '/' . preg_quote($template_extension) . '$/');
+  // Scan for template files and override their location in the theme registry.
+  $template_files = Drupal::service('cohesion.template_storage')->listAll();
 
-    foreach ($template_files as $file) {
-      $template = $file_system->basename($file->filename, $template_extension);
-      $theme_hook = str_replace('-', '_', $template);
+  foreach ($template_files as $file) {
+    $template = Drupal::service('file_system')->basename($file, '.html.twig');
+    $theme_hook = str_replace('-', '_', $template);
 
-      list($base_theme_hook, $specific) = explode('__', $theme_hook, 2);
+    [$base_theme_hook] = explode('__', $theme_hook, 2);
 
-      // Override existing theme hook or duplicate the base hook (if one exists).
-      if (isset($theme_registry[$base_theme_hook]) || $base_theme_hook === 'component') {
-        if (isset($theme_registry[$theme_hook]) && $theme_registry[$theme_hook]) {
-          $theme_registry[$theme_hook]['path'] = $template_path;
-        }
-        else {
-          // And entry to the theme registry.
-          $theme_info = isset($theme_registry[$base_theme_hook]) ? $theme_registry[$base_theme_hook] : [];
-          $theme_info['template'] = str_replace('_', '-', $theme_hook);
-          $theme_info['path'] = $template_path;
-          $theme_info['base hook'] = 'component';
-          $theme_registry[$theme_hook] = $theme_info;
-        }
+    // Override existing theme hook or duplicate the base hook (if one exists).
+    if (isset($theme_registry[$base_theme_hook]) || $base_theme_hook === 'component') {
+      if (isset($theme_registry[$theme_hook]) && $theme_registry[$theme_hook]) {
+        $theme_registry[$theme_hook]['path'] = $template_path;
+      }
+      else {
+        // And entry to the theme registry.
+        $theme_info = isset($theme_registry[$base_theme_hook]) ? $theme_registry[$base_theme_hook] : [];
+        $theme_info['template'] = str_replace('_', '-', $theme_hook);
+        $theme_info['path'] = $template_path;
+        $theme_info['base hook'] = 'component';
+        $theme_registry[$theme_hook] = $theme_info;
       }
     }
   }

--- a/cohesion.services.yml
+++ b/cohesion.services.yml
@@ -1,10 +1,18 @@
 services:
 
-  cohesion.template_storage:
+  cohesion.template_storage.database:
     class: Drupal\cohesion\DatabaseStorage
     arguments: ['@keyvalue', '@file_system']
     tags:
       - { name: twig.loader, priority: 200 }
+    # This alias determines which storage backend is the default.
+    alias: cohesion.template_storage
+
+  cohesion.template_storage.files:
+    class: Drupal\cohesion\PublicFileStorage
+    arguments: ['@twig.loader.filesystem', '@file_system']
+    tags:
+      - { name: twig.loader, priority: 198 }
 
   stream_wrapper.cohesion:
     class: Drupal\cohesion\StreamWrapper\CohesionStream

--- a/cohesion.services.yml
+++ b/cohesion.services.yml
@@ -1,5 +1,11 @@
 services:
 
+  cohesion.template_storage:
+    class: Drupal\cohesion\DatabaseStorage
+    arguments: ['@keyvalue', '@file_system']
+    tags:
+      - { name: twig.loader, priority: 200 }
+
   stream_wrapper.cohesion:
     class: Drupal\cohesion\StreamWrapper\CohesionStream
     arguments: ['@string_translation']

--- a/src/DatabaseStorage.php
+++ b/src/DatabaseStorage.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Drupal\cohesion;
+
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+use Twig\Error\LoaderError;
+use Twig\Source;
+
+/**
+ * Defines a service to store and load templates in the database.
+ */
+final class DatabaseStorage implements TemplateStorageInterface {
+
+  /**
+   * The key-value storage backend.
+   *
+   * @var \Drupal\Core\KeyValueStore\KeyValueStoreInterface
+   */
+  private $storage;
+
+  /**
+   * The file system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  private $fileSystem;
+
+  /**
+   * DatabaseStorage constructor.
+   *
+   * @param \Drupal\Core\KeyValueStore\KeyValueFactoryInterface $key_value_factory
+   *   The key-value storage factory service.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   The file system service.
+   */
+  public function __construct(KeyValueFactoryInterface $key_value_factory, FileSystemInterface $file_system) {
+    $this->storage = $key_value_factory->get('cohesion.templates');
+    $this->fileSystem = $file_system;
+  }
+
+  /**
+   * Transforms a template name into a storage key.
+   *
+   * @param string $name
+   *   The template name.
+   *
+   * @return string
+   *   A storage key that can be passed to the backend.
+   */
+  private function getKey(string $name) : string {
+    return $this->fileSystem->basename($name);
+  }
+
+  /**
+   * Loads a template or dies trying.
+   *
+   * @param string $name
+   *   The template name.
+   *
+   * @return array
+   *   A tuple containing the Twig source code of the template, and the time
+   *   stamp when it was last modified.
+   *
+   * @throws \Twig\Error\LoaderError
+   *   If the template does not exist, or is not a valid array.
+   */
+  private function loadOrDie(string $name) : array {
+    $key = $this->getKey($name);
+    $template = $this->storage->get($key);
+
+    if ($template && is_array($template)) {
+      return $template;
+    }
+    else {
+      throw new LoaderError("Unknown or invalid template: $name");
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSourceContext($name) {
+    [$template] = $this->loadOrDie($name);
+    return new Source($template, $name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheKey($name) {
+    return "$name:" . $this->getSourceContext($name)->getCode();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isFresh($name, $time) {
+    [, $changed_at] = $this->loadOrDie($name);
+    return $changed_at < $time;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function exists($name) {
+    $key = $this->getKey($name);
+    return $this->storage->has($key);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(string $name, string $content, int $time = NULL) : void {
+    $this->storage->set($this->getKey($name), [
+      $content,
+      $time ?? time(),
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function listAll() : array {
+    return array_keys($this->storage->getAll());
+  }
+
+  /**
+   * Implements LoaderInterface::getSource() for Twig 1.x compatibility.
+   */
+  public function getSource($name) {
+    return $this->getSourceContext($name)->getCode();
+  }
+
+}

--- a/src/PublicFileStorage.php
+++ b/src/PublicFileStorage.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Drupal\cohesion;
+
+use Drupal\Core\File\FileSystemInterface;
+use Twig\Error\LoaderError;
+use Twig\Loader\LoaderInterface;
+
+/**
+ * Defines a backend to store templates in the public files directory.
+ */
+final class PublicFileStorage implements TemplateStorageInterface {
+
+  /**
+   * The decorated Twig loader service.
+   *
+   * @var \Twig\Loader\LoaderInterface
+   */
+  private $twigLoader;
+
+  /**
+   * PublicFileStorage constructor.
+   *
+   * @param \Twig\Loader\LoaderInterface $twig_loader
+   *   The decorated Twig loader service.
+   */
+  public function __construct(LoaderInterface $twig_loader) {
+    $this->twigLoader = $twig_loader;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSourceContext($name) {
+    return $this->twigLoader->getSourceContext($name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheKey($name) {
+    return $this->twigLoader->getCacheKey($name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isFresh($name, $time) {
+    return $this->twigLoader->isFresh($name, $time);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function exists($name) {
+    return $this->twigLoader->exists($name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(string $name, string $content, int $time = NULL) : void {
+    $running_dx8_batch = &drupal_static('running_dx8_batch');
+    if (!$running_dx8_batch) {
+      $this->saveTemplate($content, $name);
+    }
+    else {
+      $this->saveTemporaryTemplate($content, $name);
+    }
+  }
+
+  /**
+   * Save a .twig template that has been compiled by the API.
+   *
+   * @param $content
+   * @param $filename
+   *
+   * @return bool
+   *
+   * @throws \Exception
+   */
+  private function saveTemplate($content, $filename) {
+    // Create the template twig directory if needed.
+    if (!file_exists(COHESION_TEMPLATE_PATH)) {
+      \Drupal::service('file_system')->mkdir(COHESION_TEMPLATE_PATH, 0777, FALSE);
+    }
+
+    // Save the compiled twig file.
+    $template_file = COHESION_TEMPLATE_PATH . '/' . $filename;
+    $template_saved = FALSE;
+
+    try {
+      $template_saved = \Drupal::service('file_system')->saveData($content, $template_file, FileSystemInterface::EXISTS_REPLACE);
+      \Drupal::logger('cohesion_templates')->notice("Template created: @template_file", ['@template_file' => $template_file]);
+    }
+    catch (\Throwable $e) {
+      \Drupal::service('cohesion.utils')->errorHandler('Unable to create template file: ' . $template_file . $e->getMessage());
+    }
+
+    return $template_saved;
+  }
+
+  /**
+   * When rebuilding, .twig templates are stored temporarily, so rebuilds that
+   * fail do not result in a broken looking site.
+   *
+   * @param null $data
+   * @param null $filename
+   *
+   * @return array|null
+   *
+   * @throws \Exception
+   */
+  private function saveTemporaryTemplate($data = NULL, $filename = NULL) {
+    $temp_files = [];
+    if (!$filename) {
+      return NULL;
+    }
+
+    // Build the path to the temporary file.
+    $temporary_directory = \Drupal::service('cohesion.local_files_manager')->scratchDirectory();
+    $temp_file = $temporary_directory . '/' . $filename;
+
+    if (file_put_contents($temp_file, $data) !== FALSE) {
+      // Register temporary template files.
+      $templates = \Drupal::keyValue('cohesion.temporary_template')->get('temporary_templates', []);
+      $templates[] = $temp_file;
+      \Drupal::keyValue('cohesion.temporary_template')->set('temporary_templates', $templates);
+    }
+    else {
+      \Drupal::service('cohesion.utils')->errorHandler('Unable to create template file: ' . $temp_file);
+    }
+
+    return $temp_files;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function listAll() : array {
+    // Get real path to templates and extract relative path for theme hooks.
+    // Note: The theme registry expects template paths relative to DRUPAL_ROOT.
+    $template_path = static::getTemplatePath();
+    if (empty($template_path)) {
+      return [];
+    }
+
+    if (is_dir($template_path)) {
+      $template_files = \Drupal::service('file_system')
+        ->scanDirectory($template_path, '/' . preg_quote('.html.twig') . '$/');
+    }
+    else {
+      $template_files = [];
+    }
+
+    $map = function ($file) {
+      return $file->filename;
+    };
+    return array_map($map, $template_files);
+  }
+
+  /**
+   * Returns the file system path to the Cohesion templates, if available.
+   *
+   * @return string|null
+   *   The file system path to the Cohesion templates, relative to the Drupal
+   *   root, or NULL if the Cohesion stream wrapper is unavailable.
+   */
+  public static function getTemplatePath() : ?string {
+    /** @var \Drupal\Core\StreamWrapper\LocalStream $wrapper */
+    $wrapper = \Drupal::service('stream_wrapper_manager')
+      ->getViaUri(COHESION_TEMPLATE_PATH);
+
+    if ($wrapper) {
+      return $wrapper->basePath() . '/cohesion/templates';
+    }
+    else {
+      \Drupal::logger('cohesion')
+        ->error(t('Unable to get stream wrapper for Site Studio templates path: @uri', ['@uri' => COHESION_TEMPLATE_PATH]));
+
+      return NULL;
+    }
+  }
+
+  /**
+   * Implements LoaderInterface::getSource() for Twig 1.x compatibility.
+   */
+  public function getSource($name) {
+    if (method_exists($this->twigLoader, 'getSource')) {
+      return $this->twigLoader->getSource($name);
+    }
+    else {
+      $class = get_class($this->twigLoader);
+      throw new \BadMethodCallException("Decorated loader $class does not implement LoaderInterface::getSource().");
+    }
+  }
+
+}

--- a/src/TemplateStorageInterface.php
+++ b/src/TemplateStorageInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\cohesion;
+
+use Twig\Loader\LoaderInterface;
+
+/**
+ * Defines an interface to store Cohesion templates and load them into Twig.
+ */
+interface TemplateStorageInterface extends LoaderInterface {
+
+  /**
+   * Saves a template.
+   *
+   * @param string $name
+   *   The name of the template (e.g., a file name).
+   * @param string $content
+   *   The Twig source code of the template.
+   * @param int $time
+   *   (optional) The template's modification time. Defaults to the current
+   *   time.
+   */
+  public function save(string $name, string $content, int $time = NULL) : void;
+
+  /**
+   * Lists all available templates.
+   *
+   * @return string[]
+   *   A list of all available template names.
+   */
+  public function listAll() : array;
+
+}


### PR DESCRIPTION
I've just been involved in a multi-day code blue that, while not apparently Cohesion's fault, exposes an implementation problem that needs to be solved.

Coh normally stores its templates in the public files directory, assuming -- quite reasonably -- that it's a safe, stable, non-volatile place to store templates. Unfortunately, that assumption seems to break down on Acquia hosting, where fidgety bullshit like Gluster (which is used to store public files in some situations, including Site Factory environments) causes all kinds of extremely hard-to-trace rendering bugs, simply because Gluster will often just...fail to read a file. So, effectively, the availability of the templates becomes unpredictable and unreliable at rendering time. Coh -- indeed, Drupal itself -- is not equipped to deal with this. Templates need to be consistently available, not at the mercy of a shitty filesystem.

I think one mitigation is to make Coh's template storage and retrieval mechanisms swappable. Thankfully, the Twig engine included with Drupal affords us a lot of flexibility -- we can define a "loader" service which can, essentially, get Twig source code for a specific template from...anywhere it wants to. There is no reason Cohesion couldn't store its templates in the database -- which is potentially MUCH less janky than the file system -- and load them into Twig from there.

So: this PR defines a new interface, TemplateStorageInterface, which codifies the capabilities of these services. It implements it twice: a new database-backed storage backend (which this makes into the default) and a public files directory backend, which uses existing code.

This will, if merged as-is, need an update path. One of the following things needs to happen to sites that adopt this functionality:

1. They need to run `cohesion:rebuild` right away, to load their Twig templates into the DB.
2. Coh needs to provide an update script which basically does the same thing.

Either of these is feasible, but one of them HAS to be implemented to prevent existing sites from breaking.

I wrote this PR against Drupal 9, but have tried to make it compatible with Drupal 8 as well. I look forward to seeing what thoughts you have, and hopefully getting this in!