### PR TITLE
Update cohesion.info.yml

### DIFF
--- a/cohesion.info.yml
+++ b/cohesion.info.yml
@@ -12,3 +12,4 @@ dependencies:
   - settings_tray
   - rest
   - ckeditor
+  - drupal:config


### PR DESCRIPTION
Currently assumed config will be enabled.

If configuration manager is not enabled

`ResponseText: Error: Class 'Drupal\config\StorageReplaceDataWrapper' not found in Drupal\cohesion_sync\Plugin\Sync\ConfigEntitySync->validatePackageEntryShouldApply() (line 224 of /app/docroot/modules/contrib/cohesion/modules/cohesion_sync/src/Plugin/Sync/ConfigEntitySync.php).`