### PR TITLE
feature-aco-0000: Timeout issue. Improvise Package building Process.

### DIFF
--- a/modules/cohesion_sync/cohesion_sync.services.yml
+++ b/modules/cohesion_sync/cohesion_sync.services.yml
@@ -41,3 +41,7 @@ services:
     tags:
       - { name: event_subscriber }
     arguments: ['@entity_type.manager', '@file_system', '@logger.factory']
+    
+  cohesion_sync.refresh_manager:
+    class: \Drupal\cohesion_sync\CohesionSyncRefreshManager
+    arguments: ['@entity_type.manager', '@plugin.manager.usage.processor', '@state']  

--- a/modules/cohesion_sync/drush.services.yml
+++ b/modules/cohesion_sync/drush.services.yml
@@ -32,3 +32,9 @@ services:
     arguments: ['@entity_type.manager']
     tags:
       - { name: drush.command }
+      
+  cohesion_sync.refresh:
+    class: \Drupal\cohesion_sync\Commands\CohesionSyncRefreshCommands
+    tags:
+      - { name: drush.command }
+    arguments: ['@cohesion_sync.packager', '@entity.repository', '@entity_type.manager', '@plugin.manager.usage.processor', '@cohesion_sync.refresh_manager']    

--- a/modules/cohesion_sync/src/CohesionSyncRefreshManager.php
+++ b/modules/cohesion_sync/src/CohesionSyncRefreshManager.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Drupal\cohesion_sync;
+
+use Drupal\Core\Config\Entity\ConfigEntityType;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\cohesion\UsagePluginManager;
+use Symfony\Component\HttpFoundation\Request;
+use Drupal\Core\State\StateInterface;
+
+/**
+ * Class CohesionSyncRefreshManager.
+ *
+ * @package Drupal\cohesion_sync
+ */
+class CohesionSyncRefreshManager {
+  use DependencySerializationTrait;
+
+  const PACKAGE_REQUIREMENTS = 'package_requirements';
+  const PACKAGE_CONTENTS = 'package_content';
+  const PACKAGE_EXCLUDE_ENTITY_TYPES = 'exclude_entity_types';
+
+  const COHESION_SYNC_REFRESH_REQUEST = 'cohesion_sync.refresh_request';
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * @var \Drupal\cohesion\UsagePluginManager
+   */
+  protected $usagePluginManager;
+
+  /**
+   * The state key/value store.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * CohesionSyncRefreshManager constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   * @param \Drupal\cohesion\UsagePluginManager $usagePluginManager
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state key/value store.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager,
+                              UsagePluginManager $usagePluginManager,
+                              StateInterface $state) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->usagePluginManager = $usagePluginManager;
+    $this->state = $state;
+  }
+
+  /**
+   * Helper function to set Request.
+   */
+  public function setRequestSettings(Request $request) {
+    $this->state->set(self::COHESION_SYNC_REFRESH_REQUEST, $request->getContent());
+  }
+
+  /**
+   * Helper function to get Request.
+   */
+  public function getRequestSettings() {
+    $settings = $this->state->get(self::COHESION_SYNC_REFRESH_REQUEST, FALSE);
+    if ($settings) {
+      $settings = json_decode($settings, TRUE);
+    }
+
+    return $settings;
+  }
+
+  /**
+   * Given a Usage plugin definition and an entity, get the group name. Used
+   * in the LHS panel form() to organize the entities.
+   *
+   * @param $usage
+   * @param $entity
+   * @param $all_suffix
+   *
+   * @return string
+   */
+  public function getGroupLabelFromUsage($usage, $entity, $all_suffix) {
+    $group_key_entity_type = explode(',', $usage['group_key_entity_type']);
+
+    // Get the group label.
+    if ($usage['group_key']) {
+      $label = [];
+
+      foreach (explode(',', $usage['group_key']) as $index => $group_key) {
+        // The group is the string of the group key value.
+        if (is_bool($usage['group_key_entity_type']) || (is_array($usage['group_key_entity_type']) && !$usage['group_key_entity_type'][$index])) {
+          // Probably a content template.
+          if ($group_key) {
+            $label[] = $entity->get($group_key);
+          }
+          else {
+            $label[] = 'All';
+          }
+        }
+        // If the group label is an entity reference get the label from the entity type definition.
+        else {
+          try {
+            $label[] = 'All ' . $this->entityTypeManager->getStorage($group_key_entity_type[$index])->load($entity->get($group_key))->label();
+          }
+          catch (\Throwable $e) {
+            return 'All';
+          }
+        }
+      }
+
+      return implode(' » ', $label);
+    }
+    else {
+      return 'All';
+    }
+  }
+
+  /**
+   * Create a list of entity types with definitions for the LHS requirements panel.
+   * See: form().
+   *
+   * @return array
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function getGroupsList() {
+    $list = [];
+
+    $definitions = $this->usagePluginManager->getDefinitions();
+
+    foreach ($definitions as $usage_plugin_definition) {
+      // Only include entity types that are ste to appear in this list (as defined in their Usage plugin).
+      if (!$usage_plugin_definition['exclude_from_package_requirements']) {
+        // Get the entity type definition.
+        try {
+          $entity_type_definition = $this->entityTypeManager->getDefinition($usage_plugin_definition['entity_type']);
+        }
+        catch (\Throwable $e) {
+          continue;
+        }
+
+        // Only include config entities.
+        if ($entity_type_definition instanceof ConfigEntityType) {
+          $list[$entity_type_definition->getPluralLabel()->__toString()] = [
+            'usage' => $usage_plugin_definition,
+            'entity_type' => $entity_type_definition,
+            'storage' => $this->entityTypeManager->getStorage($usage_plugin_definition['entity_type']),
+          ];
+
+        }
+      }
+    }
+
+    ksort($list);
+    return $list;
+  }
+
+}

--- a/modules/cohesion_sync/src/Commands/CohesionSyncRefreshCommands.php
+++ b/modules/cohesion_sync/src/Commands/CohesionSyncRefreshCommands.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace Drupal\cohesion_sync\Commands;
+
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drush\Commands\DrushCommands;
+use Drupal\cohesion_sync\PackagerManager;
+use Drupal\Core\Entity\EntityRepository;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\cohesion\UsagePluginManager;
+use Drupal\cohesion_sync\CohesionSyncRefreshManager;
+
+/**
+ * A Drush commandfile.
+ *
+ * In addition to this file, you need a drush.services.yml
+ * in root of your module, and a composer.json file that provides the name
+ * of the services file to use.
+ *
+ * See these files for an example of injecting Drupal services:
+ *   - http://cgit.drupalcode.org/devel/tree/src/Commands/DevelCommands.php
+ *   - http://cgit.drupalcode.org/devel/tree/drush.services.yml
+ */
+class CohesionSyncRefreshCommands extends DrushCommands {
+  use DependencySerializationTrait;
+
+  /**
+   * @var \Drupal\cohesion_sync\PackagerManager
+   */
+  protected $packagerManager;
+
+  /**
+   * @var \Drupal\Core\Entity\EntityRepository
+   */
+  protected $entityRepository;
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * @var \Drupal\cohesion\UsagePluginManager
+   */
+  protected $usagePluginManager;
+
+  /**
+   * @var \Drupal\cohesion_sync\CohesionSyncRefreshManager
+   */
+  protected $cohesionRefreshSyncManager;
+
+  /**
+   * PackageFormRefreshController constructor.
+   *
+   * @param \Drupal\cohesion_sync\PackagerManager $packagerManager
+   * @param \Drupal\Core\Entity\EntityRepository $entityRepository
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   * @param \Drupal\cohesion\UsagePluginManager $usagePluginManager
+   * @param \Drupal\cohesion_sync\CohesionSyncRefreshManager $cohesionRefreshSyncManager
+   */
+  public function __construct(PackagerManager $packagerManager,
+                              EntityRepository $entityRepository,
+                              EntityTypeManagerInterface $entityTypeManager,
+                              UsagePluginManager $usagePluginManager,
+                              CohesionSyncRefreshManager $cohesionRefreshSyncManager) {
+    $this->packagerManager = $packagerManager;
+    $this->entityRepository = $entityRepository;
+    $this->entityTypeManager = $entityTypeManager;
+    $this->usagePluginManager = $usagePluginManager;
+    $this->cohesionRefreshSyncManager = $cohesionRefreshSyncManager;
+  }
+
+  /**
+   * Export DX8 packages to sync.
+   *
+   * @validate-module-enabled cohesion_sync
+   *
+   * @param string $build_package_type
+   *   The Build Package Type.
+   *
+   * @command sync:refresh
+   * @aliases sync-refresh
+   */
+  public function refresh(string $build_package_type) {
+    // Get Request Settings.
+    $settings = $this->cohesionRefreshSyncManager->getRequestSettings();
+    $excluded_entity_type_ids = array_keys($settings['excludedSettings']);
+
+    switch ($build_package_type) {
+      case CohesionSyncRefreshManager::PACKAGE_REQUIREMENTS:
+        $requirement_batch = [
+          'title' => t('Building Package Requirements Form'),
+          'operations' => [],
+          'finished' => [CohesionSyncRefreshCommands::class, 'packageBuildFinished']
+        ];
+
+        foreach($this->cohesionRefreshSyncManager->getGroupsList() as $definition) {
+          $requirement_batch['operations'][] = [[CohesionSyncRefreshCommands::class, 'packageRequirements'], [$this->cohesionRefreshSyncManager, $definition]];
+        }
+
+        batch_set($requirement_batch);
+        break;
+
+      case CohesionSyncRefreshManager::PACKAGE_CONTENTS:
+        $content_batch = [
+          'title' => t('Building Package Contents Form'),
+          'operations' => [],
+          'finished' => [CohesionSyncRefreshCommands::class, 'packageBuildFinished']
+        ];
+
+        foreach ($settings['packageSettings'] as $uuid => $meta) {
+          $content_batch['operations'][] = [[CohesionSyncRefreshCommands::class, 'packageBuild'], [$uuid, $meta, $excluded_entity_type_ids, $this]];
+        }
+        batch_set($content_batch);
+        break;
+
+      case CohesionSyncRefreshManager::PACKAGE_EXCLUDE_ENTITY_TYPES:
+        $exclude_entities_batch = [
+          'title' => t('Build the excluded entity types list'),
+          'operations' => [],
+          'finished' => [CohesionSyncRefreshCommands::class, 'packageBuildFinished']
+        ];
+
+        foreach ($this->usagePluginManager->getDefinitions() as $item) {
+          $exclude_entities_batch['operations'][] = [[CohesionSyncRefreshCommands::class, 'excludeEntityTypes'], [$item, $this]];
+        }
+        batch_set($exclude_entities_batch);
+        break;
+    }
+
+    // Run the batch process.
+    $backend_batch_process_results = drush_backend_batch_process();
+    if (array_key_exists('drush_batch_process_finished', $backend_batch_process_results)
+      && $backend_batch_process_results['drush_batch_process_finished'] === TRUE) {
+      ksort($backend_batch_process_results[0]);
+      $batch = &batch_get();
+      $batch = NULL;
+      unset($batch);
+      return json_encode($backend_batch_process_results[0]);
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Batch dispatch submission finished callback.
+   */
+  public static function packageBuildFinished($success, $results, $operations) {
+    // The 'success' parameter means no fatal PHP errors were detected. All
+    // other error management should be handled using 'results'.
+    if ($success) {
+      $message = \Drupal::translation()
+        ->formatPlural(count($results), 'Building Package Process Completed.', '@count Building Package Processes Completed.');
+    }
+    else {
+      $message = t('Building Package Requirements Failed to Complete.');
+    }
+
+    // Display the message.
+    \Drupal::messenger()->addMessage($message);
+  }
+
+  public function packageRequirements($cohesionRefreshSyncManager, $definition, &$context) {
+    $entity_type_id = $definition['entity_type']->id();
+
+    // Build the group data (sorted by label).
+    $query = $definition['storage']->getQuery();
+    if($definition['entity_type']->hasKey('label')) {
+      $query->sort($definition['entity_type']->getKey('label'), 'ASC');
+    }
+
+    $ids = $query->execute();
+
+    $groups = [];
+
+    foreach ($definition['storage']->loadMultiple($ids) as $entity) {
+      $group_label = $cohesionRefreshSyncManager->getGroupLabelFromUsage($definition['usage'], $entity, $definition['entity_type']->getPluralLabel()->__toString());
+      $group_id = str_replace(' ', '_', $group_label);
+
+      // iI the entity is a content template, we want to filter by only modified ones.
+      if($entity_type_id != 'cohesion_content_templates' || $entity->isModified()) {
+        // Add the entity to the group array.
+        $groups[$group_id]['label'] = $group_label;
+
+        $groups[$group_id]['items'][$entity->uuid()] = [
+          'label' => $entity->label() ?? $entity->id(),
+          'type' => $definition['entity_type']->id(),
+        ];
+      }
+    }
+
+    // Set the group data including the label.
+    $package_requirements_form[$entity_type_id] = [
+      'label' => ucfirst($definition['entity_type']->getPluralLabel()->__toString()),
+      'groups' => $groups,
+      'config_type' => $definition['usage']['config_type'],
+    ];
+
+    $context['results'][] = $package_requirements_form[$entity_type_id];
+    $context['message'] = t('Created @title', array('@title' => $package_requirements_form[$entity_type_id]['label']));
+  }
+
+  public function packageBuild($uuid, $meta, $excluded_entity_type_ids, $cohesionSyncRefreshCommands, &$context) {
+    $source_entity_uuid = $uuid;
+    $source_entity_type = $meta['type'];
+
+    if ($source_entity = $cohesionSyncRefreshCommands->entityRepository->loadEntityByUuid($source_entity_type, $source_entity_uuid)) {
+      // Get details about the source entity type.
+      $source_entity_type_id = $source_entity->getEntityTypeID();
+      $source_entity_type_label = ucfirst($cohesionSyncRefreshCommands->entityTypeManager->getDefinition($source_entity_type_id)->getPluralLabel()->__toString());
+
+      // Set source entity type details in the form.
+      $package_contents_form[$source_entity_type_id]['label'] = $source_entity_type_label;
+
+      // Lop over the dependency groups.
+      $dependency_groups = [];
+      foreach ($cohesionSyncRefreshCommands->packagerManager->buildPackageEntityList([$source_entity], $excluded_entity_type_ids) as $dependency) {
+        // Get the label of the entity type.
+        $entity_type_label = ucfirst($cohesionSyncRefreshCommands->entityTypeManager->getDefinition($dependency['type'])->getPluralLabel()->__toString());
+
+        $group_id = $dependency['type'];
+
+        // Set the label of the dependency group (done repeatedly, which is a bit inefficient).
+        $dependency_groups[$group_id]['label'] = $entity_type_label;
+
+        // Set the uuid and type, etc. of the actual dependent entity.
+        $dependency_groups[$group_id]['items'][$dependency['entity']->uuid()] = [
+          'label' => $dependency['entity']->label() ?? $dependency['entity']->id(),
+          'type' => $dependency['entity']->getEntityTypeID(),
+        ];
+      }
+      ksort($dependency_groups);
+
+      // Build the top level entry.
+      $package_contents_form[$source_entity_type_id]['entities'][$source_entity->uuid()] = [
+        'label' => $source_entity->label() ?? $source_entity->id(),
+        'groups' => $dependency_groups,
+      ];
+
+      $context['results'][] = $package_contents_form[$source_entity_type_id];
+      $context['message'] = t('Created @title', array('@title' => $source_entity->label() ?? $source_entity->id()));
+    }
+  }
+
+  /**
+   * Batch to create exclude entity types array.
+   */
+  public function excludeEntityTypes($item, $cohesionSyncRefreshCommands, &$context) {
+    if ($item['exportable']) {
+      try {
+        $excluded_entity_types_form[$item['entity_type']] = [
+          'label' => $cohesionSyncRefreshCommands->entityTypeManager->getDefinition($item['entity_type'])->getPluralLabel()->__toString(),
+        ];
+
+        $context['results'][] = $excluded_entity_types_form[$item['entity_type']];
+        $context['message'] = t('Created @title', array('@title' => $excluded_entity_types_form[$item['entity_type']]['label']));
+      }
+      catch (\Exception $e) {
+        $this->logger()->error('Fetching Excluded entity types failed with error @error', ['@error' => $e->getMessage()]);
+      }
+    }
+  }
+
+}

--- a/modules/cohesion_sync/src/Controller/PackageFormRefreshController.php
+++ b/modules/cohesion_sync/src/Controller/PackageFormRefreshController.php
@@ -4,16 +4,19 @@ namespace Drupal\cohesion_sync\Controller;
 
 use Drupal\cohesion\CohesionJsonResponse;
 use Drupal\cohesion\UsagePluginManager;
-use Drupal\cohesion_sync\PackagerManager;
-use Drupal\Core\Config\Entity\ConfigEntityType;
+use Drupal\cohesion_sync\CohesionSyncRefreshManager;
 use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\cohesion_sync\PackagerManager;
+use Symfony\Component\HttpFoundation\Request;
 use Drupal\Core\Entity\EntityRepository;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 
 /**
- * Sync package form refresh controller.
+ * Class PackageFormRefreshController.
  *
  * @package Drupal\cohesion_sync\Controller
  */
@@ -40,18 +43,32 @@ class PackageFormRefreshController extends ControllerBase {
   protected $usagePluginManager;
 
   /**
-   * PackageFormRefreshController constructor.
-   *
-   * @param \Drupal\cohesion_sync\PackagerManager $packagerManager
-   * @param \Drupal\Core\Entity\EntityRepository $entityRepository
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   * @param \Drupal\cohesion\UsagePluginManager $usagePluginManager
+   * @var \Drupal\cohesion\CohesionSyncRefreshManager
    */
-  public function __construct(PackagerManager $packagerManager, EntityRepository $entityRepository, EntityTypeManagerInterface $entityTypeManager, UsagePluginManager $usagePluginManager) {
+  protected $cohesionRefreshSyncManager;
+
+  /**
+   * The logger factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(PackagerManager $packagerManager,
+                              EntityRepository $entityRepository,
+                              EntityTypeManagerInterface $entityTypeManager,
+                              UsagePluginManager $usagePluginManager,
+                              CohesionSyncRefreshManager $cohesionRefreshSyncManager,
+                              LoggerChannelFactoryInterface $logger_factory) {
     $this->packagerManager = $packagerManager;
     $this->entityRepository = $entityRepository;
     $this->entityTypeManager = $entityTypeManager;
     $this->usagePluginManager = $usagePluginManager;
+    $this->cohesionRefreshSyncManager = $cohesionRefreshSyncManager;
+    $this->loggerFactory = $logger_factory->get('cohesion_sync');
   }
 
   /**
@@ -60,7 +77,14 @@ class PackageFormRefreshController extends ControllerBase {
    * @return static
    */
   public static function create(ContainerInterface $container) {
-    return new static($container->get('cohesion_sync.packager'), $container->get('entity.repository'), $container->get('entity_type.manager'), $container->get('plugin.manager.usage.processor'));
+    return new static(
+      $container->get('cohesion_sync.packager'),
+      $container->get('entity.repository'),
+      $container->get('entity_type.manager'),
+      $container->get('plugin.manager.usage.processor'),
+      $container->get('cohesion_sync.refresh_manager'),
+      $container->get('logger.factory'),
+    );
   }
 
   /**
@@ -76,145 +100,23 @@ class PackageFormRefreshController extends ControllerBase {
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function index(Request $request) {
-    // Decode the settings sent from the app.
-    $settings = json_decode($request->getContent(), TRUE);
+    // Store the Request Content in Drupal State to fetch across requests.
+    $this->cohesionRefreshSyncManager->setRequestSettings($request);
 
     /**
      * Build the package requirements form.
      */
-    $package_requirements_form = [];
-
-    foreach ($this->getGroupsList() as $definition) {
-      $entity_type_id = $definition['entity_type']->id();
-
-      // Build the group data (sorted by label).
-      $query = $definition['storage']->getQuery();
-      if ($definition['entity_type']->hasKey('label')) {
-        $query->sort($definition['entity_type']->getKey('label'), 'ASC');
-      }
-
-      $ids = $query->execute();
-
-      $groups = [];
-
-      foreach ($definition['storage']->loadMultiple($ids) as $entity) {
-        $group_label = $this->getGroupLabelFromUsage($definition['usage'], $entity, $definition['entity_type']->getPluralLabel()->__toString());
-        $group_id = str_replace(' ', '_', $group_label);
-
-        // iI the entity is a content template, we want to filter by only modified ones.
-        if ($entity_type_id != 'cohesion_content_templates' || $entity->isModified()) {
-          // Add the entity to the group array.
-          $groups[$group_id]['label'] = $group_label;
-
-          $groups[$group_id]['items'][$entity->uuid()] = [
-            'label' => $entity->label() ?? $entity->id(),
-            'type' => $definition['entity_type']->id(),
-          ];
-        }
-      }
-
-      // Set the group data including the label.
-      $package_requirements_form[$entity_type_id] = [
-        'label' => ucfirst($definition['entity_type']->getPluralLabel()->__toString()),
-        'groups' => $groups,
-        'config_type' => $definition['usage']['config_type'],
-      ];
-    }
+    $package_requirements_form = $this->initBackendProcess(CohesionSyncRefreshManager::PACKAGE_REQUIREMENTS);
 
     /**
      * Build the package contents form.
      */
-    $excluded_entity_type_ids = array_keys($settings['excludedSettings']);
-    $package_contents_form = [];
-
-    // Group uuids to be processed by entity type
-    // to use loadMultiple instead of loading by UUID one by one
-    // for better performance
-    $typed_uuids = [];
-
-    foreach ($settings['packageSettings'] as $uuid => $meta) {
-      $typed_uuids[$meta['type']][] = $uuid;
-    }
-
-    foreach ($typed_uuids as $type => $uuids) {
-      $entity_type = $this->entityTypeManager->getDefinition($type);
-      // Get the ids for all uuids and load the entities
-      $ids = $this->entityTypeManager->getStorage($type)
-        ->getQuery()
-        ->condition($entity_type->getKey('uuid'), $uuids, 'IN')
-        ->execute();
-
-      $entities = $this->entityTypeManager->getStorage($type)
-        ->loadMultiple($ids);
-
-      // Loop through the results and add them to the dependencies.
-      foreach ($entities as $source_entity) {
-        // Get details about the source entity type.
-        $source_entity_type_id = $source_entity->getEntityTypeID();
-        $source_entity_type_label = ucfirst($this->entityTypeManager->getDefinition($source_entity_type_id)->getPluralLabel()->__toString());
-
-        // Set source entity type details in the form.
-        $package_contents_form[$source_entity_type_id]['label'] = $source_entity_type_label;
-
-        // Loop over the dependency groups.
-        $dependency_groups = [];
-        $dependencies = [];
-        foreach ($this->packagerManager->buildPackageEntityList([$source_entity], $excluded_entity_type_ids) as $dependency) {
-          $dependencies[] = $dependency['entity']->uuid();
-
-          // Get the label of the entity type.
-          $entity_type_label = ucfirst($this->entityTypeManager->getDefinition($dependency['type'])->getPluralLabel()->__toString());
-
-          $group_id = $dependency['type'];
-
-          // Set the label of the dependency group (done repeatedly, which is a bit inefficient).
-          $dependency_groups[$group_id]['label'] = $entity_type_label;
-
-          // Set the uuid and type, etc. of the actual dependent entity.
-          $dependency_groups[$group_id]['items'][$dependency['entity']->uuid()] = [
-            'label' => $dependency['entity']->label() ?? $dependency['entity']->id(),
-            'type' => $dependency['entity']->getEntityTypeID(),
-          ];
-        }
-        ksort($dependency_groups);
-
-        // check if the dependencies and the package contents have the same items.
-        $items_to_remove = [];
-        foreach($meta['items'] as $i => $item) {
-          if(!in_array($i, $dependencies)) {
-            $items_to_remove[] = $i;
-          }
-        }
-
-        $no_longer_dependencies = $items_to_remove;
-
-        // Build the top level entry.
-        $package_contents_form[$source_entity_type_id]['entities'][$source_entity->uuid()] = [
-          'label' => $source_entity->label() ?? $source_entity->id(),
-          'groups' => $dependency_groups,
-        ];
-      }
-    }
-
-    ksort($package_contents_form);
+    $package_contents_form = $this->initBackendProcess(CohesionSyncRefreshManager::PACKAGE_CONTENTS);
 
     /**
      * Build the excluded entity types list.
      */
-    $excluded_entity_types_form = [];
-    foreach ($this->usagePluginManager->getDefinitions() as $item) {
-      if ($item['exportable'] && $item['can_be_excluded']) {
-        try {
-          $excluded_entity_types_form[$item['entity_type']] = [
-            'label' => $this->entityTypeManager->getDefinition($item['entity_type'])->getPluralLabel()->__toString(),
-          ];
-        }
-        catch (\Throwable $e) {
-          continue;
-        }
-      }
-    }
-    ksort($excluded_entity_types_form);
+    $excluded_entity_types_form = $this->initBackendProcess(CohesionSyncRefreshManager::PACKAGE_EXCLUDE_ENTITY_TYPES);
 
     /**
      * Return the forms to the app.
@@ -224,96 +126,30 @@ class PackageFormRefreshController extends ControllerBase {
       'packageRequirementsForm' => $package_requirements_form,
       'packageContentsForm' => $package_contents_form,
       'excludedEntityTypesForm' => $excluded_entity_types_form,
-      'noLongerDependencies' => $no_longer_dependencies ?? []
     ]);
   }
 
   /**
-   * Given a Usage plugin definition and an entity, get the group name. Used
-   * in the LHS panel form() to organize the entities.
-   *
-   * @param $usage
-   * @param $entity
-   * @param $all_suffix
-   *
-   * @return string
+   * Init Backend Process to build the Package.
    */
-  private function getGroupLabelFromUsage($usage, $entity, $all_suffix) {
-    $group_key_entity_type = explode(',', $usage['group_key_entity_type']);
-
-    // Get the group label.
-    if ($usage['group_key']) {
-      $label = [];
-
-      foreach (explode(',', $usage['group_key']) as $index => $group_key) {
-
-        // The group is the string of the group key value.
-        if (!$usage['group_key_entity_type']) {
-          // Probably a content template.
-          if ($group_key) {
-            $label[] = $entity->get($group_key);
-          }
-          else {
-            $label[] = 'All';
-          }
-        }
-        // If the group label is an entity reference get the label from the entity type definition.
-        else {
-          try {
-            $label[] = 'All ' . $this->entityTypeManager->getStorage($group_key_entity_type[$index])->load($entity->get($group_key))->label();
-          }
-          catch (\Throwable $e) {
-            return 'All';
-          }
-        }
-      }
-
-      return implode(' » ', $label);
-    }
-    else {
-      return 'All';
-    }
-  }
-
-  /**
-   * Create a list of entity types with definitions for the LHS requirements panel.
-   * See: form().
-   *
-   * @return array
-   *
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
-   */
-  private function getGroupsList() {
-    $list = [];
-
-    $definitions = $this->usagePluginManager->getDefinitions();
-
-    foreach ($definitions as $usage_plugin_definition) {
-      // Only include entity types that are ste to appear in this list (as defined in their Usage plugin).
-      if (!$usage_plugin_definition['exclude_from_package_requirements']) {
-        // Get the entity type definition.
-        try {
-          $entity_type_definition = $this->entityTypeManager->getDefinition($usage_plugin_definition['entity_type']);
-        }
-        catch (\Throwable $e) {
-          continue;
-        }
-
-        // Only include config entities.
-        if ($entity_type_definition instanceof ConfigEntityType) {
-          $list[$entity_type_definition->getPluralLabel()->__toString()] = [
-            'usage' => $usage_plugin_definition,
-            'entity_type' => $entity_type_definition,
-            'storage' => $this->entityTypeManager->getStorage($usage_plugin_definition['entity_type']),
-          ];
-
-        }
+  public function initBackendProcess(string $build_package_type) {
+    $build_package_process_output = [];
+    $process = new Process("drush @self sync-refresh $build_package_type");
+    $process->setTimeout(1200);
+    $process->setIdleTimeout(600);
+    try {
+      $process->mustRun();
+      if ($process->isSuccessful()) {
+        $build_package_process_output = json_decode($process->getOutput(), TRUE);
+        $this->loggerFactory->info('Completed the Build Package of Type @build_package_type', ['@build_package_type' => $build_package_type]);
       }
     }
+    catch(ProcessFailedException $process_Exception) {
+      $this->loggerFactory
+        ->error('Failed to Complete the Package Build Process with @type and @error', ['@type' => $build_package_type, '@error' => $process_Exception->getMessage()]);
+    }
 
-    ksort($list);
-    return $list;
+    return $build_package_process_output;
   }
 
 }


### PR DESCRIPTION
### Improvise Package building feature using Symphony Process with Drush and Batch API running in background to avoid timeout issues

![Rakshith_package_build](https://user-images.githubusercontent.com/13797228/138426208-3b0913a8-0c1a-4568-9b2e-a46e8f1b8e38.png)
**Background**:

- Currently when trying to add new package [**_admin/cohesion/sync/packages/add_**] - User can select different components to be exported to package.
- However, as Site studio components increase - it will be very difficult to select options and generate the package.
- As package building happens in single call - it is obvious that developers will face timeout issues and also gateway timeout issues in case of CDNs ex: Akamai.

**Proposed Solution:**

- I have used the [Process](https://symfony.com/doc/current/components/process.html) component from Symphony
- Whenever Package build is called - 3 different calls will happen to generate Package Requirements, Package Content and Exclude Entity types.
- The Process will trigger drush command which in turn [Batch API](https://api.drupal.org/api/drupal/core%21includes%21form.inc/group/batch/9.0.x) from Drupal.
- I have also made sure the batch process runs in backend and with multiple requests happening with virtue of batch - timeout issue is avoided. The full package can be easily generated.
