### PR TITLE
Site studio rebuild issue with bool entity.

### DIFF
--- a/modules/cohesion_sync/src/Controller/BatchImportController.php
+++ b/modules/cohesion_sync/src/Controller/BatchImportController.php
@@ -11,6 +11,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Installer\InstallerKernel;
 use Drupal\Core\Url;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Sync batch import controller.
@@ -407,7 +408,9 @@ class BatchImportController extends ControllerBase {
         ->getStorage($entity_type)
         ->loadByProperties(['uuid' => $uuid]);
       $entity = reset($entities);
-      $usage_update_manager->buildRequires($entity);
+      if ($entity instanceof EntityInterface) {
+        $usage_update_manager->buildRequires($entity);
+      }
     }
 
   }


### PR DESCRIPTION
Resolve issue with package rebuild 
`[33mIn ProcessBase.php line 171:[39m
[37;41m                                                                               [39;49m
[37;41m  [InvalidArgumentException]                                                   [39;49m
[37;41m  Unable to decode output into JSON: Syntax error                              [39;49m
[37;41m                                                                               [39;49m
[37;41m  TypeError: Drupal\cohesion\UsageUpdateManager::buildRequires(): Argument #1  [39;49m
[37;41m   ($entity) must be of type Drupal\Core\Entity\EntityInterface, bool given,   [39;49m
[37;41m  called in /mnt/www/html/veoliaportal01dev/docroot/modules/contrib/cohesion/  [39;49m
[37;41m  modules/cohesion_sync/src/Controller/BatchImportController.php on line 410   [39;49m
[37;41m  in Drupal\cohesion\UsageUpdateManager->buildRequires() (line 159 of /mnt/ww  [39;49m
[37;41m  w/html/veoliaportal01dev/docroot/modules/contrib/cohesion/src/UsageUpdateMa  [39;49m
[37;41m  nager.php).                                                                  [39;49m
[37;41m`