### PR TITLE
Fix file usages not working for s3 files.

### DIFF
--- a/src/Plugin/Usage/FileUsage.php
+++ b/src/Plugin/Usage/FileUsage.php
@@ -112,7 +112,7 @@ class FileUsage extends UsagePluginBase {
 
     // This regex now handles spaces in filenames.
     $this->uriRegex = '/(?<!"preview_image":{"id":")((' . implode('|', array_keys($this->wrappers)) . '):\/\/(.*?)\.(.*?))([\s|:"*?<>|\\\\]|$)/m';
-    $this->mediaReferenceRegex = '/\[media-reference:file:(.*?)\]/m';
+    $this->mediaReferenceRegex = '#(?:<img[^>]*data-entity-uuid=\\\"([^"]+)\\\"[^>]*src=\\\"([^"]+)\\\"|\[media-reference:file:([^\]]+)\])#i';
     $this->fileRepository = $fileRepository;
   }
 

--- a/src/Plugin/Usage/FileUsage.php
+++ b/src/Plugin/Usage/FileUsage.php
@@ -187,6 +187,16 @@ class FileUsage extends UsagePluginBase {
   private function registerCoreFileUsage($files, EntityInterface $entity) {
 
     if ($entity->id() && strlen($entity->id()) < 32) {
+
+      // Load previously referenced file IDs so we can invalidate their cache.
+      $existingFids = $this->connection->select('file_usage', 'fu')
+        ->fields('fu', ['fid'])
+        ->condition('module', 'cohesion')
+        ->condition('type', $entity->getEntityTypeId())
+        ->condition('id', $entity->id())
+        ->execute()
+        ->fetchCol();
+
       // Remove 'cohesion' registered usage of all files for scanned entity.
       try {
         $this->connection->delete('file_usage')
@@ -197,6 +207,14 @@ class FileUsage extends UsagePluginBase {
       }
       catch (\Throwable $e) {
         return;
+      }
+
+      // Invalidate cache for files that were previously referenced.
+      if (!empty($existingFids)) {
+        $existingFiles = $this->storage->loadMultiple($existingFids);
+        foreach ($existingFiles as $existingFile) {
+          $this->refreshFileListCache($existingFile);
+        }
       }
 
       // Add file usages back in one by one, so we end up with the correct count
@@ -319,10 +337,7 @@ class FileUsage extends UsagePluginBase {
       }
     }
 
-    // Register file usages with core 'file.usage'.
-    if (!empty($files)) {
-      $this->registerCoreFileUsage($files, $entity);
-    }
+    $this->registerCoreFileUsage($files, $entity);
 
     return $entities;
   }


### PR DESCRIPTION
**Motivation**
File usage not working properly for S3 files.
This makes the files temporary despite being added on a component.

**Proposed changes**
Update mediaReferenceRegex to include the format for s3 files.

**Testing steps**
Install s3fs module. 
Update the your text editor to use s3.
Edit a page with layout canvas.
Add component that use WYSIWIG/CK Editor.
Add and upload file to the editor the save.

File is still temporary.
