### PR TITLE
Prevent creating duplicate files if assets and public stream is in same path.

### DIFF
--- a/src/Plugin/Usage/FileUsage.php
+++ b/src/Plugin/Usage/FileUsage.php
@@ -110,6 +110,11 @@ class FileUsage extends UsagePluginBase {
       $this->wrappers[$key]['instance'] = $stream_wrapper_manager->getViaUri($key . '://');
     }
 
+    // Ensure 'public' is processed before 'asset' in convertBasepathsToUris
+    // so base-path URIs resolve to public:// (the canonical form) and don't
+    // create duplicate file entities when both wrappers share the same path.
+    uksort($this->wrappers, fn($a, $b) => ($b === 'public') <=> ($a === 'public') ?: strcmp($a, $b));
+
     // This regex now handles spaces in filenames.
     $this->uriRegex = '/(?<!"preview_image":{"id":")((' . implode('|', array_keys($this->wrappers)) . '):\/\/(.*?)\.(.*?))([\s|:"*?<>|\\\\]|$)/m';
     $this->mediaReferenceRegex = '/\[media-reference:file:(.*?)\]/m';


### PR DESCRIPTION
**Motivation**

Site Studio’s file scanning process could create duplicate file_managed records for the same physical file. This happened when asset:// and public:// pointed to the same directory, but asset:// was processed first. In that case, Site Studio stored the file using an asset:// URI instead of matching the existing public:// record, resulting in duplicate file entities and incorrect file usage tracking.

**Proposed changes**

Sort the stream wrappers in FileUsage::__construct() so public is always processed first when converting file paths to stream wrapper URIs. This ensures files resolve consistently to public://, preventing duplicate file entities from being created for the same file.

No updates or migrations are required. Existing duplicate records created before this fix may still need manual cleanup.